### PR TITLE
Get rid of * in directory name

### DIFF
--- a/nautica-downloader.js
+++ b/nautica-downloader.js
@@ -274,7 +274,7 @@ class NauticaDownloader {
         meta.users = {};
       }
 
-      const userDirectoryName = this.cleanName(user.name);  
+      const userDirectoryName = this.cleanName(user.name.replace("*",""));  
       meta.users[user.id] = userDirectoryName;
       fs.writeFileSync(path.resolve('./nautica/meta.json'), JSON.stringify(meta), 'utf8');
       return userDirectoryName;


### PR DESCRIPTION
Not sure if this is just a Windows thing but it refuses to create a directory for Schrik* because of the asterisk, so now it just gets rid of that when making the directory (it's now just Schrik)